### PR TITLE
Add useful tools and begin template clean up

### DIFF
--- a/app/utils/filters-with-app-context.js
+++ b/app/utils/filters-with-app-context.js
@@ -1,0 +1,68 @@
+const helpers = require('./helpers')
+
+// Add Nunjucks filters with access to app, req and res
+module.exports = (nunjucksAppEnv, app) => {
+  app.use((req, res, next) => {
+    // Add name, value, id, idPrefix and checked attributes to GOVUK form inputs
+    // Generate the attributes based on where they are stored in the data object
+    //
+    // Example:
+    // {{ govukInput({
+    //   label: { text: "Label" }
+    // } | decorateFormAttributes(['some', 'section'])) }}
+    nunjucksAppEnv.addFilter('decorateFormAttributes', (obj, sections) => {
+      sections = Array.isArray(sections) ? sections : [sections]
+      var storedValue = helpers.getDataValue(req.session.data, sections)
+
+      if (obj.items !== undefined) {
+        obj.items = obj.items.map(item => {
+          var checked = storedValue ? '' : item.checked
+          var selected = storedValue ? '' : item.selected
+          if (typeof item.value === 'undefined') {
+            item.value = item.text
+          }
+
+          // If data is an array, check it exists in the array
+          if (Array.isArray(storedValue)) {
+            if (storedValue.indexOf(item.value) !== -1) {
+              checked = 'checked'
+              selected = 'selected'
+            }
+          } else {
+            // The data is just a simple value, check it matches
+            if (storedValue === item.value) {
+              checked = 'checked'
+              selected = 'selected'
+            }
+          }
+
+          item.checked = checked
+          item.selected = selected
+          return item
+        })
+
+        obj.idPrefix = sections.join('-')
+      } else {
+        obj.value = storedValue
+      }
+
+      if (typeof obj.id === 'undefined') {
+        obj.id = sections.join('-')
+      }
+      obj.name = sections.map(s => `[${s}]`).join('')
+      return obj
+    })
+
+    // Retrieve the value of something
+    // Designed as a replacement to `data[thing][thing]`
+    nunjucksAppEnv.addGlobal('dataValue', (sections) => {
+      if (sections && !Array.isArray(sections)) {
+        sections = [sections]
+      }
+
+      return helpers.getDataValue(req.session.data, sections)
+    })
+
+    next()
+  })
+}

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -1,0 +1,23 @@
+const getKeypath = require('keypather/get')
+const setKeypath = require('keypather/set')
+
+const generateRandomString = (length) => {
+  length = length || 3
+  return Math.random().toString(36).substr(2, length).toUpperCase()
+}
+
+const getDataValue = (data, sections) => {
+  sections = Array.isArray(sections) ? sections : [sections]
+  return getKeypath(data, sections.map(s => `["${s}"]`).join(''))
+}
+
+const setDataValue = (data, sections, value) => {
+  sections = Array.isArray(sections) ? sections : [sections]
+  return setKeypath(data, sections.map(s => `["${s}"]`).join(''), value)
+}
+
+module.exports = {
+  generateRandomString,
+  getDataValue,
+  setDataValue
+}

--- a/app/utils/wizard-helpers.js
+++ b/app/utils/wizard-helpers.js
@@ -1,0 +1,73 @@
+const helpers = require('./helpers')
+
+function originalQuery (req) {
+  var originalQueryString = req.originalUrl.split('?')[1]
+  return originalQueryString ? `?${originalQueryString}` : ''
+}
+
+function nextAndBackPaths (paths, req) {
+  const currentPath = req.path
+  const query = originalQuery(req)
+  const data = req.session.data
+  const index = paths.indexOf(currentPath)
+  const next = paths[index + 1] || ''
+  let back = paths[index - 1] || ''
+
+  // Point back to where we forked from
+  if (currentPath === data['forked-to']) {
+    back = data['forked-from']
+  }
+
+  // Remove the saved fork if we return to it
+  if (currentPath === data['forked-from'] && req.method === 'GET') {
+    delete data['forked-from']
+    delete data['forked-to']
+  }
+
+  return {
+    next: next + query,
+    back: back + query,
+    current: currentPath + query
+  }
+}
+
+function nextForkPath (forks, req) {
+  const currentPath = req.path
+  const data = req.session.data
+  const fork = forks.find(obj => { return obj.currentPath === currentPath })
+
+  if (fork) {
+    const storedData = helpers.getDataValue(req.session.data, fork.storedData)
+    const storedValues = Array.isArray(storedData) ? storedData : [storedData]
+    const forkPath = (typeof fork.forkPath === 'function' ? fork.forkPath(storedData) : fork.forkPath)
+
+    if (fork.values) {
+      const values = Array.isArray(fork.values) ? fork.values : [fork.values]
+
+      if (values.some(v => storedValues.indexOf(v) >= 0)) {
+        data['forked-from'] = currentPath
+        data['forked-to'] = forkPath
+
+        return forkPath
+      }
+    }
+
+    if (fork.excludedValues) {
+      const excludedValues = Array.isArray(fork.excludedValues) ? fork.excludedValues : [fork.excludedValues]
+
+      if (!excludedValues.some(v => storedValues.indexOf(v) >= 0)) {
+        data['forked-from'] = currentPath
+        data['forked-to'] = forkPath
+
+        return forkPath
+      }
+    }
+  }
+
+  return false
+}
+
+module.exports = {
+  nextAndBackPaths,
+  nextForkPath
+}

--- a/app/views/_OLD/_OLD_ect-induction-course-outline.html
+++ b/app/views/_OLD/_OLD_ect-induction-course-outline.html
@@ -4,17 +4,6 @@
   Induction course
 {% endblock %}
 
-{% block beforeContent %}
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 <a href="/sign-out" class="signout">Sign out</a>
   <div class="govuk-grid-row">

--- a/app/views/_OLD/_OLD_guidance_1.html
+++ b/app/views/_OLD/_OLD_guidance_1.html
@@ -4,14 +4,7 @@
   Induction training and support for new teachers
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <li class="govuk-breadcrumbs__list-item">

--- a/app/views/_OLD/_OLD_prove-identity.html
+++ b/app/views/_OLD/_OLD_prove-identity.html
@@ -4,14 +4,7 @@
   Choose how to continue
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/start">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/OLD_register-school-1.html
+++ b/app/views/_OLD/register-school/OLD_register-school-1.html
@@ -4,14 +4,7 @@
   Before you start
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/sign-in">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-later-no-decision.html
+++ b/app/views/_OLD/register-school/register-later-no-decision.html
@@ -4,15 +4,8 @@
   You can register later
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/register-school/register-school-3">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/register-school/register-school-3">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/_OLD/register-school/register-later-no-participants.html
+++ b/app/views/_OLD/register-school/register-later-no-participants.html
@@ -4,14 +4,7 @@
   You can register later
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/register-school/register-school-2">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-school-2.html
+++ b/app/views/_OLD/register-school/register-school-2.html
@@ -4,15 +4,8 @@
   Register your school
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/sign-in">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/sign-in">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/_OLD/register-school/register-school-3.html
+++ b/app/views/_OLD/register-school/register-school-3.html
@@ -4,14 +4,7 @@
   Register your school
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/register-school/register-school-2">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-school-4.html
+++ b/app/views/_OLD/register-school/register-school-4.html
@@ -4,14 +4,7 @@
   Register your school
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/register-school/register-school-3">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-school-5.html
+++ b/app/views/_OLD/register-school/register-school-5.html
@@ -4,14 +4,7 @@
   Register your school
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/register-school/register-school-4">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-school-6.html
+++ b/app/views/_OLD/register-school/register-school-6.html
@@ -4,14 +4,7 @@
   Register your school
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/register-school/register-school-5">Back</a>
 {% endblock %}
 

--- a/app/views/_OLD/register-school/register-school-8.html
+++ b/app/views/_OLD/register-school/register-school-8.html
@@ -4,16 +4,6 @@
   Your school is now registered
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/cip-course-guidance.html
+++ b/app/views/cip-course-guidance.html
@@ -1,28 +1,13 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  Induction training and support for new teachers
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-{% endblock %}
+{% set title = 'Choose study materials for your early career teachers' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <h1 class="govuk-heading-xl">
-        Choose study materials for your early career teachers
+        {{ title }}
       </h1>
-
 
       <p>It’s important to choose the right training materials for your school.</p>
 
@@ -332,5 +317,4 @@
 
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -1,31 +1,14 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  Continue to your account
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
+{% set title = 'Dashboard' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-xl">
         Dashboard
       </h1>
-
       <p class="govuk-body">You should not be seeing this page.</p>
-
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/guidance_1.html
+++ b/app/views/guidance_1.html
@@ -1,35 +1,26 @@
 {% extends "layout.html" %}
+{% set title = 'Induction training and support for new teachers' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Induction training and support for new teachers
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/start">Start</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link">Induction training and support for new teachers</a>
-      </li>
-    </ol>
-  </div>
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Start",
+        href: "/start"
+      },
+      {
+        text: title
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Induction training and support for new teachers
+        {{ title }}
       </h1>
 
       <p class='govuk-body'>From September 2021, new teachers in England must complete a 2-year induction after they have done their initial teacher training (ITT).</p>
@@ -58,8 +49,6 @@
       <p class='govuk-body'>[Find a training provider] </p>
       <p class='govuk-body'>[Free online materials] designed by education experts are also available. </p>
       <p class='govuk-body'>Alternatively, schools can design and deliver their own induction programme based on the ECF.</p>
-
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,19 +1,16 @@
-
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK Prototype Kit
+  ECF Register and Partner prototype
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">ECF Register and Partner</span>
       <h1 class="govuk-heading-xl">
         Prototype admin
       </h1>
-
     </div>
   </div>
 
@@ -45,7 +42,6 @@
       <div class="index-group">
         <h2 class="govuk-heading-l">School induction tutors / leads</h2>
         <dl class='govuk-list app-list--definition'>
-          <br />
           <h2 class="govuk-heading-m">Nominations</h2>
           <dt><a href='school-nominate-school-lead/nominate-school-lead-1' class="govuk-link--no-visited-state">Nominating an Induction Tutor</a>.</dt>
           <dd>School admin staff (or those monitoring the "main GIAS email address") recieve an email and are asked to nominate their Induction Tutors. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457354086350072&cot=14">User journey on Miro</a></span></dd>
@@ -53,27 +49,22 @@
           <dd>Users trigger the resending of the nomination email, because either the original email has been lost / deleted or the link in it has expired. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355253267755&cot=14">User journey on Miro</a></span></dd>
           <dt><a href='school-lead-notification-and-sign-in/notification-of-school-lead' class="govuk-link--no-visited-state">Notification of Induction Tutor and sign in</a></dt>
           <dd>Induction Tutor is notified via email that they have been nominated, and follows instructions to sign in. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355250705583&cot=14">User journey on Miro</a></span></dd>
-          <br /><br />
 
-
-          <h2 class="govuk-heading-m">Signed in: choose programme and next steps</h2>
+          <h2 class="govuk-heading-m govuk-!-margin-top-6">Signed in: choose programme and next steps</h2>
           <dt><a href='/school-signed-in/no-decision/pre-choose-provision' class="govuk-link--no-visited-state">Dashboard: School not in partnership or not chosen programme yet</a></dt>
           <dd>What a school sees after first sign in, or if they haven't chosen a programme yet. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355290069818&cot=14">User journey on Miro</a></span></dd>
           <dt><a href='/school-signed-in/fip/fip-choose-cohort' class="govuk-link--no-visited-state">Dashboard: School preparing to do a FIP</a></dt>
           <dd>What a school sees after sign in, if they have chosen the FIP programme or if they have entered into a partnership. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355306758748&cot=14">User journey on Miro</a></span></dd>
           <dt><a href='/school-signed-in/cip/cip-choose-cohort' class="govuk-link--no-visited-state">Dashboard: School preparing to do a CIP</a></dt>
           <dd>What a school sees after sign in, if they have chosen the CIP programme. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355308879313&cot=14">User journey on Miro</a></span></dd>
-          <br /><br />
 
-
-          <h2 class="govuk-heading-m">Partnerships</h2>
+          <h2 class="govuk-heading-m govuk-!-margin-top-6">Partnerships</h2>
           <dt><a href='/school-challenging-partnership/school-challenge-1' class="govuk-link--no-visited-state">Notify an induction tutor that they've been recruited by a provider, and report if it's incorrect</a></dt>
           <dd>The nominated induction tutor is notified via email of a new partnership and can challenge / reporting mistake a with a partnership, or sign in. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457354439630103&cot=14">User journey on Miro</a></span></dd>
           <dt><a href='/school-challenging-partnership/school-challenge-gias' class="govuk-link--no-visited-state">Notify a school that they've been recruited by a provider, and report if it's incorrect</a></dt>
           <dd>The GIAS email address for a school is notified via email of a new partnership and can challenge / reporting mistake a with a partnership, or sign in. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457354439630103&cot=14">User journey on Miro</a></span></dd>
 
-          <br /><br />
-          <h2 class="govuk-heading-m">Onboarding participants</h2>
+          <h2 class="govuk-heading-m govuk-!-margin-top-6">Onboarding participants</h2>
           <dt><a href="/school-signed-in/school-add-participants-to-cohort/choose-participant-type">School induction tutor adding participants to a cohort</a></dt>
           <dd>How a school induction tutor adds both ECTs and Mentors to a cohort. This covers creating new participants, and also adding Mentors who exist in other cohorts (ie. have been previously validated). <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457356227023262&cot=14">User journey on Miro</a></span></dd>
 
@@ -93,12 +84,6 @@
         </dl>
       </div>
       -->
-
-      <p classs="govuk-!-margin-bottom-9">&nbsp;</p>
-
     </div>
-
-
   </div>
-
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -43,7 +43,7 @@
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,
-    serviceUrl: "/",
+    serviceUrl: "/start",
     containerClasses: "govuk-width-container"
   }) }}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -48,6 +48,21 @@
   }) }}
 {% endblock %}
 
+{% block beforeContent %}
+  {% if showPhaseBanner != false %}
+    {{ govukPhaseBanner({
+      tag: {
+        text: "Prototype"
+      },
+      html: "This is a prototype. It is not a real service."
+    }) }}
+  {% endif %}
+  {% block pageNavigation %}
+  {% endblock %}
+  {% block pageBanner %}
+  {% endblock %}
+{% endblock %}
+
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
 {% if useAutoStoreData %}

--- a/app/views/pseudo-email-sign-in.html
+++ b/app/views/pseudo-email-sign-in.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set showPhaseBanner = false %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />

--- a/app/views/pseudo-email-training-provider-invite.html
+++ b/app/views/pseudo-email-training-provider-invite.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set showPhaseBanner = false %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />

--- a/app/views/school-challenging-partnership/school-challenge-2.html
+++ b/app/views/school-challenging-partnership/school-challenge-2.html
@@ -13,16 +13,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-challenging-partnership/school-challenge-3.html
+++ b/app/views/school-challenging-partnership/school-challenge-3.html
@@ -13,16 +13,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-nominate-school-lead/nominate-school-lead-2.html
+++ b/app/views/school-nominate-school-lead/nominate-school-lead-2.html
@@ -13,17 +13,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<!-- <a class="govuk-back-link" href="/sign-in">Back</a> -->
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-nominate-school-lead/nominate-school-lead-3.html
+++ b/app/views/school-nominate-school-lead/nominate-school-lead-3.html
@@ -13,17 +13,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<!-- <a class="govuk-back-link" href="/sign-in">Back</a> -->
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-nominate-school-lead/nominate-school-lead-4.html
+++ b/app/views/school-nominate-school-lead/nominate-school-lead-4.html
@@ -13,16 +13,6 @@ Induction lead or tutor nominated
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-resend-nomination-email/resend-nomination-1.html
+++ b/app/views/school-resend-nomination-email/resend-nomination-1.html
@@ -13,15 +13,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/sign-in">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/sign-in">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-resend-nomination-email/resend-nomination-2.html
+++ b/app/views/school-resend-nomination-email/resend-nomination-2.html
@@ -13,15 +13,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-resend-nomination-email/resend-nomination-1">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-resend-nomination-email/resend-nomination-1">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-resend-nomination-email/resend-nomination-3.html
+++ b/app/views/school-resend-nomination-email/resend-nomination-3.html
@@ -13,15 +13,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-resend-nomination-email/resend-nomination-2">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-resend-nomination-email/resend-nomination-2">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-resend-nomination-email/resend-nomination-4.html
+++ b/app/views/school-resend-nomination-email/resend-nomination-4.html
@@ -13,16 +13,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-signed-in/cip/cip-add-participants.html
+++ b/app/views/school-signed-in/cip/cip-add-participants.html
@@ -24,15 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/cip/cip-choose-cohort.html
+++ b/app/views/school-signed-in/cip/cip-choose-cohort.html
@@ -24,18 +24,7 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/cip/cip-choose-provision.html
+++ b/app/views/school-signed-in/cip/cip-choose-provision.html
@@ -24,14 +24,7 @@ Choose your induction programme
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
 {% endblock %}
 

--- a/app/views/school-signed-in/cip/cip-cohort-detail.html
+++ b/app/views/school-signed-in/cip/cip-cohort-detail.html
@@ -24,16 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/cip/cip-choose-cohort">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/cip/cip-choose-cohort">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/cip/cip-course-choice.html
+++ b/app/views/school-signed-in/cip/cip-course-choice.html
@@ -24,15 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/cip/cip-which-course">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/cip/cip-which-course">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/cip/cip-course-confirmed.html
+++ b/app/views/school-signed-in/cip/cip-course-confirmed.html
@@ -24,16 +24,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-signed-in/cip/cip-course-decision.html
+++ b/app/views/school-signed-in/cip/cip-course-decision.html
@@ -24,15 +24,8 @@ Your accredited materials
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/cip/cip-which-course.html
+++ b/app/views/school-signed-in/cip/cip-which-course.html
@@ -24,15 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/fip/fip-add-participants.html
+++ b/app/views/school-signed-in/fip/fip-add-participants.html
@@ -24,19 +24,11 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/fip/fip-choose-cohort.html
+++ b/app/views/school-signed-in/fip/fip-choose-cohort.html
@@ -24,18 +24,7 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/fip/fip-choose-provision.html
+++ b/app/views/school-signed-in/fip/fip-choose-provision.html
@@ -24,15 +24,8 @@ Choose your induction programme
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/fip/fip-cohort-detail.html
+++ b/app/views/school-signed-in/fip/fip-cohort-detail.html
@@ -24,16 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/fip/fip-choose-cohort">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/fip/fip-choose-cohort">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/fip/fip-find-training-provider.html
+++ b/app/views/school-signed-in/fip/fip-find-training-provider.html
@@ -24,15 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/no-decision/confirm-decision.html
+++ b/app/views/school-signed-in/no-decision/confirm-decision.html
@@ -24,15 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/school-signed-in/no-decision/prompt-choose-provision">Back</a>
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/no-decision/prompt-choose-provision">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/school-signed-in/no-decision/pre-choose-provision.html
+++ b/app/views/school-signed-in/no-decision/pre-choose-provision.html
@@ -24,18 +24,7 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/no-decision/privacy-policy.html
+++ b/app/views/school-signed-in/no-decision/privacy-policy.html
@@ -24,16 +24,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-signed-in/no-decision/prompt-choose-provision.html
+++ b/app/views/school-signed-in/no-decision/prompt-choose-provision.html
@@ -24,20 +24,11 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
+{% block pageNavigation %}
 <a class="govuk-back-link" href="/school-signed-in/no-decision/pre-choose-provision">Back</a>
 {% endblock %}
 
-
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/no-decision/provision-confirmed.html
+++ b/app/views/school-signed-in/no-decision/provision-confirmed.html
@@ -24,18 +24,7 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/choose-mentor-for-ect.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/choose-mentor-for-ect.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
   <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/enter-personal-details">Back</a>
-
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/choose-participant-type.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/choose-participant-type.html
@@ -24,23 +24,14 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-{% if (data['schoolParticipantOptions'] === 'hasAddedMentors') %}
-  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-{% elseif (data['schoolParticipantOptions'] === 'canAddParticipants' and data['journey-mode'] === 'schoolFIP') %}
-  <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
-{% elseif (data['schoolParticipantOptions'] === 'canAddParticipants' and data['journey-mode'] === 'schoolCIP') %}
-    <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
-{% endif %}
-
+{% block pageNavigation %}
+  {% if (data['schoolParticipantOptions'] === 'hasAddedMentors') %}
+    <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
+  {% elseif (data['schoolParticipantOptions'] === 'canAddParticipants' and data['journey-mode'] === 'schoolFIP') %}
+    <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
+  {% elseif (data['schoolParticipantOptions'] === 'canAddParticipants' and data['journey-mode'] === 'schoolCIP') %}
+      <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
+  {% endif %}
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing.html
@@ -24,22 +24,12 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-
-{% if (data['journey-mode'] === 'schoolFIP') %}
-  <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
-{% elseif (data['journey-mode'] === 'schoolCIP') %}
-  <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
-{% endif %}
-
+{% block pageNavigation %}
+  {% if (data['journey-mode'] === 'schoolFIP') %}
+    <a class="govuk-back-link" href="/school-signed-in/fip/fip-cohort-detail">Back</a>
+  {% elseif (data['journey-mode'] === 'schoolCIP') %}
+    <a class="govuk-back-link" href="/school-signed-in/cip/cip-cohort-detail">Back</a>
+  {% endif %}
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/confirm-participant-details.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/confirm-participant-details.html
@@ -24,21 +24,12 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-{% if (data['schoolParticipantOptions'] === 'hasAddedMentors') %}
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/choose-mentor-for-ect">Back</a>
-{% else %}
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/enter-personal-details">Back</a>
-{% endif %}
-
+{% block pageNavigation %}
+  {% if (data['schoolParticipantOptions'] === 'hasAddedMentors') %}
+    <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/choose-mentor-for-ect">Back</a>
+  {% else %}
+    <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/enter-personal-details">Back</a>
+  {% endif %}
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/enter-personal-details.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/enter-personal-details.html
@@ -24,25 +24,13 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-
-
-{% if (data['participantType'] === 'ect') %}
-  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/choose-participant-type">Back</a>
-{% elseif (data['participantType'] === 'mentor') %}
-  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/new-or-existing-mentor">Back</a>
-{% else %}
-
-{% endif %}
-
+{% block pageNavigation %}
+  {% if (data['participantType'] === 'ect') %}
+    <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/choose-participant-type">Back</a>
+  {% elseif (data['participantType'] === 'mentor') %}
+    <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/new-or-existing-mentor">Back</a>
+  {% else %}
+  {% endif %}
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/mentor-from-existing-cohort.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/mentor-from-existing-cohort.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
   <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/new-or-existing-mentor">Back</a>
-
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/new-or-existing-mentor.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/new-or-existing-mentor.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
   <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/choose-participant-type">Back</a>
-
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-approved.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-approved.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-investigate.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-investigate.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-not-started.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-not-started.html
@@ -24,17 +24,8 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
 
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-on-dqt-update.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-on-dqt-update.html
@@ -24,19 +24,9 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
-
 
 {% block content %}
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-on-qts-status.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-on-qts-status.html
@@ -24,19 +24,9 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
-
 
 {% block content %}
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-to-be-added-to-dqt.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/participant-status-waiting-to-be-added-to-dqt.html
@@ -24,19 +24,9 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
-
+{% block pageNavigation %}
+  <a class="govuk-back-link" href="/school-signed-in/school-add-participants-to-cohort/cohort-participant-listing">Back</a>
 {% endblock %}
-
 
 {% block content %}
 

--- a/app/views/school-signed-in/school-add-participants-to-cohort/success-mentor-added.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/success-mentor-added.html
@@ -24,17 +24,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/school-signed-in/school-add-participants-to-cohort/success-participant-added.html
+++ b/app/views/school-signed-in/school-add-participants-to-cohort/success-participant-added.html
@@ -24,17 +24,6 @@
 }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/sign-in-check-account.html
+++ b/app/views/sign-in-check-account.html
@@ -1,47 +1,27 @@
 {% extends "layout.html" %}
+{% set title = 'How to get an account for this service' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  How to get an account for this service
-{% endblock %}
-
-{% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({
-  homepageUrl: "/index",
-  serviceName: "Manage training for early career teachers",
-  serviceUrl: "/start"
-}) }}
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/sign-in">Back</a>
+{% block pageNavigation %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/sign-in"
+  }) }}
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      <h1 class="govuk-heading-xl">How to get an account for this service</h1>
-    <h2 class="govuk-heading-m">Schools</h2>
-    <p class="govuk-body">Your school has been sent an email to nominate someone who manages statutory inductions at your school.</p>
-    <p class="govuk-body">We cannot disclose the email address. It will be an administration email, for example, office@, admin@ or head@</p>
-    <p><a class="govuk-link" href="/school-resend-nomination-email/resend-nomination-1">Resend email</a></p>
-    <h2 class="govuk-heading-m">New teachers or mentors</h2>
-    <p class="govuk-body">You only need to sign in if you’re using our accredited training materials. We will send you sign in details before you start your programme.</p>
-    <h2 class="govuk-heading-m">Training providers</h2>
-    <p class="govuk-body">The Department for Education creates your account.<br>Contact: <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
-</p>
-
-
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
+      <h2 class="govuk-heading-m">Schools</h2>
+      <p class="govuk-body">Your school has been sent an email to nominate someone who manages statutory inductions at your school.</p>
+      <p class="govuk-body">We cannot disclose the email address. It will be an administration email, for example, office@, admin@ or head@</p>
+      <p><a class="govuk-link" href="/school-resend-nomination-email/resend-nomination-1">Resend email</a></p>
+      <h2 class="govuk-heading-m">New teachers or mentors</h2>
+      <p class="govuk-body">You only need to sign in if you’re using our accredited training materials. We will send you sign in details before you start your programme.</p>
+      <h2 class="govuk-heading-m">Training providers</h2>
+      <p class="govuk-body">The Department for Education creates your account.<br>Contact: <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
+      </p>
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/sign-in-check-email.html
+++ b/app/views/sign-in-check-email.html
@@ -1,51 +1,24 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-   We’ve sent you a link to sign in
-{% endblock %}
-
-{% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({
-  homepageUrl: "/index",
-  serviceName: "Manage training for early career teachers",
-  serviceUrl: "/start"
-}) }}
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
+{% set title = 'Check your email' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Check your email</h1>
-    <p class="govuk-body">If you have an account, we have sent you a link to sign in.</p>
-    <h2 class="govuk-heading-m">If you don’t get an email to sign in</h2>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you must be nominated or sent sign in details to access this service. <a class="govuk-link" href="/sign-in-check-account">Find out how to get an account</a></li>
-      <li>check your spam or junk folder</li>
-      <li>contact us: <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
-</li>
-    </ul>
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
+      <p class="govuk-body">If you have an account, we have sent you a link to sign in.</p>
+      <h2 class="govuk-heading-m">If you don’t get an email to sign in</h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you must be nominated or sent sign in details to access this service. <a class="govuk-link" href="/sign-in-check-account">Find out how to get an account</a></li>
+        <li>check your spam or junk folder</li>
+        <li>contact us: <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
+        </li>
+      </ul>
 
-
-      {% if (data['journey-mode'] == "noemailsrecieved") %}
-
-      {% else %}
+      {% if not (data['journey-mode'] == "noemailsrecieved") %}
         <p class="govuk-body skip-to">Skip to: <a href="/pseudo-email-sign-in">Example email</a></p>
       {% endif %}
-
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/sign-in-continue-to-account.html
+++ b/app/views/sign-in-continue-to-account.html
@@ -1,45 +1,18 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  You are now signed in
-{% endblock %}
-
-{% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({
-  homepageUrl: "/index",
-  serviceName: "Manage training for early career teachers",
-  serviceUrl: "/start"
-}) }}
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
+{% set title = 'You are now signed in' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-xl">
-        You are now signed in
+        {{ title }}
       </h1>
-
-      <form class="form" action="/dashboard" method="post" class="govuk-!-margin-bottom-8">
-        {% from "govuk/components/button/macro.njk" import govukButton %}
+      <form class="form" action="/dashboard" method="post">
         {{ govukButton({
           text: "Continue"
         }) }}
       </form>
-
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/sign-in.html
+++ b/app/views/sign-in.html
@@ -1,61 +1,48 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  Sign in
-{% endblock %}
+{% block pageTitle %}Sign in{% endblock %}
 
 {% block header %}
-  <!-- Blank header with no service name for the start page -->
   {{ govukHeader({
-  homepageUrl: "/index",
-  serviceName: "Manage training for early career teachers",
-  serviceUrl: "/start"
-}) }}
+    homepageUrl: "/index",
+    serviceName: "Manage training for early career teachers",
+    serviceUrl: "/start"
+  }) }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<a class="govuk-back-link" href="/start">Back</a>
+{% block pageNavigation %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/start"
+  }) }}
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-xl">
         Sign in
       </h1>
 
       <form class="form" action="/sign-in-check-email" method="post">
-      {% from "govuk/components/input/macro.njk" import govukInput %}
-      {{ govukInput({
-        label: {
-          text: "Email address"
-        },
-        classes: "govuk-input--width-20",
-        id: "sign-in-email-address",
-        name: "sign-in-email-address"
-      }) }}
-      {% from "govuk/components/button/macro.njk" import govukButton %}
-      {{ govukButton({
-        text: "Sign in"
-      }) }}
+        {{ govukInput({
+          label: {
+            text: "Email address"
+          },
+          classes: "govuk-input--width-20",
+          id: "sign-in-email-address",
+          name: "sign-in-email-address"
+        }) }}
+
+        {{ govukButton({
+          text: "Sign in"
+        }) }}
       </form>
 
       <h2 class="govuk-heading-m">How you can access this service</h2>
       <ul class="govuk-list govuk-list--bullet">
-      <li>you must be nominated or sent sign in details to access this service. <a class="govuk-link" href="/sign-in-check-account">Find out how to get an account</a></li>
-      <li>we don't use DfE sign in or passwords, you just need your account's email address</li>
-    </ul>
-
+        <li>you must be nominated or sent sign in details to access this service. <a class="govuk-link" href="/sign-in-check-account">Find out how to get an account</a></li>
+        <li>we don't use DfE sign in or passwords, you just need your account's email address</li>
+      </ul>
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/sign-out.html
+++ b/app/views/sign-out.html
@@ -1,40 +1,14 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  You are signed out
-{% endblock %}
-
-{% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({
-  homepageUrl: "/index",
-  serviceName: "Manage training for early career teachers",
-  serviceUrl: "/start"
-}) }}
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
+{% set title = 'You are signed out' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-xl">
-        You have signed out
+        {{ title}}
       </h1>
-
       <p class="govuk-body">You can close this tab or <a href="/sign-in">sign in again</a>.</p>
-
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/start-testing.html
+++ b/app/views/start-testing.html
@@ -1,32 +1,9 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-  Journey settings
-{% endblock %}
+{% block pageTitle %}Journey settings{% endblock %}
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
   {{ govukHeader() }}
-{% endblock %}
-
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-<div class="govuk-breadcrumbs">
-  <ol class="govuk-breadcrumbs__list">
-    <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="#">Home</a>
-    </li>
-    <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="#">Department for Education</a>
-    </li>
-  </ol>
-</div>
 {% endblock %}
 
 {% block content %}
@@ -114,7 +91,6 @@
             </fieldset>
             </div>
 
-            {% from "govuk/components/radios/macro.njk" import govukRadios %}
             {{ govukRadios({
               idPrefix: "schoolParticipantOptions",
               name: "schoolParticipantOptions",
@@ -148,7 +124,6 @@
 
           </div>
 
-          {% from "govuk/components/button/macro.njk" import govukButton %}
           {{ govukButton({
             text: "Save journey"
           }) }}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -1,58 +1,42 @@
 {% extends "layout.html" %}
-
-{% block pageTitle %}
-Manage training for early career teachers
-{% endblock %}
+{% set title = 'Manage training for early career teachers' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
   {{ govukHeader() }}
 {% endblock %}
 
-{% block beforeContent %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
+      <p class="govuk-body">This service is for induction leads/tutors nominated by their school.</p>
 
-      <h1 class="govuk-heading-xl">Manage training for early career teachers</h1>
-    <p class="govuk-body">This service is for induction leads/tutors nominated by their school.</p>
+      <p>Use this service to manage your school’s statutory induction programme for early career teachers.</p>
 
-    <p>Use this service to manage your school’s statutory induction programme for early career teachers.</p>
+      <p>Only use this service if your school wants to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>use an approved training provider</li>
+      </ul>
+      <p>Or</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>use the DfE accredited materials</li>
+      </ul>
 
-    <p>Only use this service if your school wants to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>use an approved training provider</li>
-    </ul>
-    <p>Or</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>use the DfE accredited materials</li>
-    </ul>
+      <p>Your school must complete these steps before your early career teachers (ECTs) start their statutory induction programme. For example, if your ECTs are starting in September, you need to complete these steps before then.</p>
 
-    <p>Your school must complete these steps before your early career teachers (ECTs) start their statutory induction programme.
-      For example, if your ECTs are starting in September, you need to complete these steps before then.</p>
+      {{ govukButton({
+        text: "Start now",
+        href: "/sign-in",
+        isStartButton: true
+      }) }}
 
-      <a href="/sign-in" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-bottom-8" data-module="govuk-button">
-    Start now
-    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-    </svg></a>
-
-    <h2 class="govuk-heading-m">Do you have an account?</h2>
-    <p class="govuk-body">Your school has been sent an email to nominate an induction lead or tutor. This is someone who manages statutory inductions at your school.</p>
-    <p class="govuk-body">We cannot disclose the email address. It will be an administration email, for example, office@, admin@ or head@</p>
-    <p class="govuk-body"><a class="govuk-link" href="/nominations/choose-location">Resend email</a></p>
-
+      <h2 class="govuk-heading-m">Do you have an account?</h2>
+      <p class="govuk-body">Your school has been sent an email to nominate an induction lead or tutor. This is someone who manages statutory inductions at your school.</p>
+      <p class="govuk-body">We cannot disclose the email address. It will be an administration email, for example, office@, admin@ or head@</p>
+      <p class="govuk-body"><a class="govuk-link" href="/nominations/choose-location">Resend email</a></p>
     </div>
-
     <div class="govuk-grid-column-one-third">
       <!--
       <aside class="app-related-items" role="complementary">
@@ -71,7 +55,5 @@ Manage training for early career teachers
       </aside>
       -->
     </div>
-
-
   </div>
 {% endblock %}

--- a/app/views/training-provider-signed-in/cohort-listing.html
+++ b/app/views/training-provider-signed-in/cohort-listing.html
@@ -1,54 +1,35 @@
 {% extends "layout.html" %}
+{% set title = 'Cohorts' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Cohorts
-{% endblock %}
+{% block pageNavigation %}
+  <nav class="app-navigation govuk-clearfix">
+    <ul class="app-navigation__list app-width-container">
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
+      </li>
+      <li class="app-navigation__list-item app-navigation__list-item--current">
+        <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/cohort-listing">Cohorts</a>
+      </li>
+      <li class="app-navigation__list-item">
+        <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing">Schools</a>
+      </li>
+    </ul>
+  </nav>
 
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
-<nav class="app-navigation govuk-clearfix">
-  <ul class="app-navigation__list app-width-container">
-
-    <li class="app-navigation__list-item">
-      <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
-    </li>
-
-    <li class="app-navigation__list-item app-navigation__list-item--current">
-      <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/cohort-listing">Cohorts</a>
-    </li>
-
-    <li class="app-navigation__list-item">
-      <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing">Schools</a>
-    </li>
-
-  </ul>
-</nav>
-{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-<a class="govuk-back-link" href="/training-provider-signed-in/dashboard-training-provider">Back</a>
+  {{ govukBackLink({
+    text: "Back",
+    href: "/training-provider-signed-in/dashboard-training-provider"
+  }) }}
 {% endblock %}
 
 {% block content %}
-
-  <div class="govuk-grid-row govuk-!-margin-bottom-5">
-    <div class="govuk-grid-column-one-half">
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
-        Cohorts
-      </h1>
-    </div>
-  </div>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+        {{ title }}
+      </h1>
+
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -67,5 +48,4 @@
       </table>
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/training-provider-signed-in/dashboard-training-provider.html
+++ b/app/views/training-provider-signed-in/dashboard-training-provider.html
@@ -1,50 +1,27 @@
 {% extends "layout.html" %}
+{% set title = 'Lorem Ipsum Education Ltd.' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Dashboard
-{% endblock %}
-
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <h1 class="govuk-heading-xl">
-        Lorem Ipsum Education Ltd.
+        {{ title }}
       </h1>
 
-    </div>
-  </div>
-
-  <div class="govuk-grid-row govuk-!-margin-bottom-6">
-    <div class="govuk-grid-column-two-thirds">
       <div class="index-group">
         <h2 class="govuk-heading-m"><a href="/training-provider-signed-in/find-and-add-schools" class="govuk-link--no-visited-state">Find and add schools</a></h2>
         <p class="govuk-body">Search for schools you want to recruit and add schools you have partnered with.</p>

--- a/app/views/training-provider-signed-in/find-and-add-schools-confirm.html
+++ b/app/views/training-provider-signed-in/find-and-add-schools-confirm.html
@@ -1,35 +1,17 @@
 {% extends "layout.html" %}
+{% block pageTitle %}Confirm partnerships{% endblock %}
 
-{% block pageTitle %}
-  Confirm partnerships
-{% endblock %}
-
-{% block beforeContent %}
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 {{ govukBackLink({
   text: "Back",
   href: "/training-provider-signed-in/find-and-add-schools-results"
@@ -37,7 +19,6 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-three-quarters">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">

--- a/app/views/training-provider-signed-in/find-and-add-schools-results.html
+++ b/app/views/training-provider-signed-in/find-and-add-schools-results.html
@@ -1,36 +1,18 @@
 {% extends "layout.html" %}
+{% set title = 'Search results' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Search results
-{% endblock %}
-
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 {{ govukBackLink({
   text: "Back",
   href: "/training-provider-signed-in/find-and-add-schools"
@@ -38,15 +20,11 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-        Search results
+        {{ title }}
       </h1>
-      <!-- 
-      <p class="govuk-body-l">Schools matching in the <strong>'Abbey Academies Trust'</strong> establishment group</p>
-      -->
     </div>
   </div>
 

--- a/app/views/training-provider-signed-in/find-and-add-schools-success.html
+++ b/app/views/training-provider-signed-in/find-and-add-schools-success.html
@@ -1,39 +1,20 @@
 {% extends "layout.html" %}
+{% block pageTitle %}Partnerships have been added{% endblock %}
 
-{% block pageTitle %}
-  Partnerships have been added
-{% endblock %}
-
-{% block beforeContent %}
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-panel govuk-panel--confirmation">
@@ -44,29 +25,26 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">What happens next</h2>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-8">
         <li>we will notify the schools and remind them to add their early career teachers and mentors</li>
         <li>you can check your schools to make sure they have done this and follow up if need be. This will ensure you are paid in time for your participants</li>
       </ul>
+
+      {{ govukButton({
+        text: 'Add more schools',
+        href: '/training-provider-signed-in/find-and-add-schools'
+      }) }}
+
+      <div>
+      {{ govukButton({
+        text: 'Check your schools',
+        href: '/training-provider-signed-in/school-listing-2021',
+        classes: 'govuk-button--secondary'
+      }) }}
+      </div>
     </div>
   </div>
-
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-
-      <form class="form" action="/training-provider-signed-in/find-and-add-schools" method="post" class="govuk-!-margin-bottom-8">
-        <button type="submit" class="govuk-button" id="name-search-submit" name="SearchType" value="Text">Add more schools</button>
-      </form>
-
-      <form class="form" action="/training-provider-signed-in/school-listing-2021" method="post" class="govuk-!-margin-bottom-8">
-        <button class="govuk-button govuk-button--secondary" data-module="govuk-button">Check your schools</button>
-      </form>
-
-    </div>
-  </div>
-
 {% endblock %}

--- a/app/views/training-provider-signed-in/find-and-add-schools.html
+++ b/app/views/training-provider-signed-in/find-and-add-schools.html
@@ -1,48 +1,26 @@
 {% extends "layout.html" %}
+{% set title = 'Find and add schools' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Find and add schools
-{% endblock %}
-
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
 {% endblock %}
 
 {% block content %}
-
-  <div class="govuk-grid-row govuk-!-margin-bottom-5">
-    <div class="govuk-grid-column-one-half">
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-        Find and add schools
-      </h1>
-    </div>
-  </div>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+        {{ title }}
+      </h1>
 
       <p class="govuk-body">Use the search to:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
@@ -216,5 +194,4 @@
 
     </div>
   </div>
-
 {% endblock %}

--- a/app/views/training-provider-signed-in/school-detail-zero.html
+++ b/app/views/training-provider-signed-in/school-detail-zero.html
@@ -1,34 +1,18 @@
 {% extends "layout.html" %}
+{% set title = 'Vale Valley Primary School' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Vale Valley Primary School
-{% endblock %}
-{% block beforeContent %}
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-
-{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
 {{ govukBreadcrumbs({
   items: [
     {
@@ -48,7 +32,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
-        Vale Valley Primary School
+        {{ title }}
       </h1>
     </div>
   </div>

--- a/app/views/training-provider-signed-in/school-detail.html
+++ b/app/views/training-provider-signed-in/school-detail.html
@@ -1,34 +1,18 @@
 {% extends "layout.html" %}
+{% set title = 'Abacus Primary School' %}
+{% block pageTitle %}{{ title }}{% endblock %}
 
-{% block pageTitle %}
-  Abacus Primary School
-{% endblock %}
-{% block beforeContent %}
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-
-{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
 {{ govukBreadcrumbs({
   items: [
     {
@@ -48,7 +32,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
-        Abacus Primary School
+        {{ title }}
       </h1>
     </div>
   </div>

--- a/app/views/training-provider-signed-in/school-listing-2021.html
+++ b/app/views/training-provider-signed-in/school-listing-2021.html
@@ -4,32 +4,17 @@
   Your schools: 2021 cohort
 {% endblock %}
 
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
-
 {% endblock %}
 
 {% block content %}
@@ -42,7 +27,6 @@
     </div>
     <div class="govuk-grid-column-one-half">
       <form class="form top-right" action="find-and-add-schools" method="post" class="govuk-!-margin-bottom-9">
-      {% from "govuk/components/button/macro.njk" import govukButton %}
       {{ govukButton({
         text: "Find and add schools"
       }) }}

--- a/app/views/training-provider-signed-in/school-listing-2022.html
+++ b/app/views/training-provider-signed-in/school-listing-2022.html
@@ -1,46 +1,25 @@
 {% extends "layout.html" %}
+{% block pageTitle %}Your schools: 2022 cohort{% endblock %}
 
-{% block pageTitle %}
-  Your schools: 2022 cohort
-{% endblock %}
-
-{% block beforeContent %}
-
-
-
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner({
-  tag: {
-    text: "prototype"
-  },
-  html: 'This isn&apos;t a real service'
-}) }}
-
+{% block pageNavigation %}
 <nav class="app-navigation govuk-clearfix">
   <ul class="app-navigation__list app-width-container">
-
     <li class="app-navigation__list-item">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/dashboard-training-provider">Overview</a>
     </li>
-
     <li class="app-navigation__list-item app-navigation__list-item--current">
       <a class="govuk-link govuk-link--no-visited-state app-navigation__link" href="/training-provider-signed-in/school-listing-2021">Schools</a>
     </li>
-
   </ul>
 </nav>
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row govuk-!-margin-bottom-5">
     <div class="govuk-grid-column-one-half">
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
         Your schools
       </h1>
-    </div>
-    <div class="govuk-grid-column-one-half">
-      
     </div>
   </div>
 
@@ -74,7 +53,4 @@
       <p class="govuk-body">You cannot recruit in this cohort yet</p>
     </div>
   </div>
-
-
-
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const packageJson = require('./package.json')
 const routes = require('./app/routes.js')
 const utils = require('./lib/utils.js')
 const extensions = require('./lib/extensions/extensions.js')
+const addNunjucksFiltersWithAppContext = require('./app/utils/filters-with-app-context')
 
 // Variables for v6 backwards compatibility
 // Set false by default, then turn on if we find /app/v6/routes.js
@@ -102,6 +103,9 @@ var nunjucksAppEnv = nunjucks.configure(appViews, nunjucksConfig)
 
 // Add Nunjucks filters
 utils.addNunjucksFilters(nunjucksAppEnv)
+
+// Add Nunjucks filters with access to app, req and res
+addNunjucksFiltersWithAppContext(nunjucksAppEnv, app)
 
 // Set views engine
 app.set('view engine', 'html')


### PR DESCRIPTION
- Add form decorator for simpler nunjucks macros
- Add helper for generating IDs (useful for very dynamic prototypes)
- Add "wizard helper", for defining long page-per-thing journeys and logic for fork-points (avoids having to edit back/action links over and over again)
- Begin cleanup of templates – refactor phase banner into layout and remove `beforeContent` blocks