### PR TITLE
Content for no ECTs and 'Are you sure you want to change' screens

### DIFF
--- a/app/views/sprint-20/schools/choose-induction-programme.html
+++ b/app/views/sprint-20/schools/choose-induction-programme.html
@@ -37,7 +37,7 @@
 			  
   
 			  <!-- <h2 class="govuk-heading-m">If you’re not sure what to choose</h2> -->
-			  <p>If you’re not sure which type of training to choose, check our guidance on <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview">statutory changes and new training programmes</a>.</p>
+			  <p>If you’re not sure which option to choose, <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview">check our guidance on statutory changes and new training programmes</a>.</p>
 			  <!-- <ul class="govuk-list govuk-list--bullet">
 				  <li>the changes to statutory induction</li>
 				  {% if data['eligible-funding'] == "No" %}
@@ -69,9 +69,9 @@
 							idPrefix: "induction-programme",
 							name: "induction-programme",
 							items: [
-								{ value: "FIP", text: "Use a training provider, funded by the DfE (full induction programme)", checked: checked("induction-programme", "FIP") },
-								{ value: "CIP", text: "Deliver your own programme using DfE accredited materials (core induction programme)", checked: checked("induction-programme", "CIP") },							
-								{ value: "noECT", text: "We don’t expect to have any early career teachers starting in 2021", checked: checked("induction-programme", "noECT") }
+								{ value: "FIP", text: "Use a training provider, funded by the DfE", checked: checked("induction-programme", "FIP") },
+								{ value: "CIP", text: "Deliver your own programme using DfE accredited materials", checked: checked("induction-programme", "CIP") },							
+								{ value: "noECT", text: "We do not expect any early career teachers to join", checked: checked("induction-programme", "noECT") }
 							]
 						}) }}
 
@@ -81,7 +81,7 @@
 						<!-- No work on this as yet -->
 					{% elif data['induction-programme'] == "FIP" %}
 						
-						<p>You have not selected an induction programme</p>
+						<p>You have not selected how to run your training programme.</p>
 
 					{% endif %}
 
@@ -94,10 +94,10 @@
 						name: "induction-programme",
 						items: [
 							
-							{ value: "CIP", text: "Deliver your own programme using DfE accredited materials (core induction programme)", checked: checked("induction-programme", "CIP") },
+							{ value: "CIP", text: "Deliver your own programme using DfE accredited materials", checked: checked("induction-programme", "CIP") },
 							{ value: "DYO", text: "Design and deliver your own programme based on the Early Career Framework (ECF)", checked: checked("induction-programme", "DYO") },
 							{ value: "temphold", text: "Use a training provider funded by your school ", checked: checked("induction-programme", "temphold") },
-							{ value: "noECT", text: "We don’t expect to have any early career teachers starting in 2021", checked: checked("induction-programme", "noECT") }
+							{ value: "noECT", text: "We do not expect any early career teachers to join", checked: checked("induction-programme", "noECT") }
 						]
 					}) }}
 
@@ -107,10 +107,10 @@
 						idPrefix: "induction-programme",
 						name: "induction-programme",
 						items: [
-							{ value: "FIP", text: "Use a training provider, funded by the DfE (full induction programme)", checked: checked("induction-programme", "FIP") },
-							{ value: "CIP", text: "Deliver your own programme using DfE accredited materials (core induction programme)", checked: checked("induction-programme", "CIP") },
+							{ value: "FIP", text: "Use a training provider, funded by the DfE", checked: checked("induction-programme", "FIP") },
+							{ value: "CIP", text: "Deliver your own programme using DfE accredited materials", checked: checked("induction-programme", "CIP") },
 							{ value: "DYO", text: "Design and deliver your own programme based on the Early Career Framework (ECF)", checked: checked("induction-programme", "DYO") },
-							{ value: "noECT", text: "We don’t expect to have any early career teachers starting in 2021", checked: checked("induction-programme", "noECT") }
+							{ value: "noECT", text: "We do not expect any early career teachers to join", checked: checked("induction-programme", "noECT") }
 						]
 					}) }}
 

--- a/app/views/sprint-20/schools/confirm-induction-programme.html
+++ b/app/views/sprint-20/schools/confirm-induction-programme.html
@@ -21,21 +21,33 @@
 
 				{% if (data['induction-programme'] === "FIP") %}
 
-					<p>You’ll need to follow the steps to choose a training provider and add your ECTs and mentors.</p>
+					<p>You have chosen to use a training provider, funded by the DfE.</p>
+					<p>You’ll need to follow the steps to:
+						<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+							<li>choose a training provider </li>
+							<li>add your ECTs and mentors.</li>
+						</ul>
 
 				{% elseif (data['induction-programme'] === "CIP") %}
-
-					<p>You’ll need to follow the steps to choose your training materials and add your ECTs and mentors.</p>
+					
+					<p>You have chosen to deliver your own programme using DfE accredited materials.</p>
+					<p>You’ll need to follow the steps to:
+					<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+						<li>choose your training materials</li>
+						<li>add your ECTs and mentors</li>
+					</ul>					
 				
 				{% elseif (data['induction-programme'] === "DYO") %}
 
 					<!-- noECT to DIY  -->
+					<p>You are choosing to design and deliver your own programme based on the Early Career Framework (ECF).</p>
 					<p class="govuk-body">You’ll need to design a 2-year programme of support and training that covers every ’learn that’ and ’learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
 					<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
 				
 				{% elseif (data['induction-programme'] === "noECT") %}
 					
 					<!-- DIY to noECT -->
+					<p>You are not expecting any early career teachers to join.</p>
 					<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
 					<p>If any ECTs do join your school this year, you need to use this service to let us know.</p>				
 			

--- a/app/views/sprint-20/schools/confirm-induction-programme.html
+++ b/app/views/sprint-20/schools/confirm-induction-programme.html
@@ -2,7 +2,7 @@
 {% set schoolSignedIn = true %}
 
 {% if data['change-programme'] == "Yes" %}
-	{% set pageHeading = "New heading needed for change programme confirm" %}
+	{% set pageHeading = "Are you sure you want to change how you'll run your training?" %}
 {% else %}
 	{% set pageHeading = "Confirm your training programme" %}
 {% endif %}
@@ -19,20 +19,44 @@
 
 			{% if data['change-programme'] == "Yes" %}
 
-			<p>Placeholder for the new content for when the user has changed their induction programme.</p>
+			<p>**Brian - I think we need to make variable content for each of the combinations below**</p>
+
+			<p>[[If changing from DIY or no ECT to FIP]]</p> 
+			<p>You'll need to follow the steps to choose a training provider and add your ECTs and mentors.</p>
+
+			<p>[[If changing from DIY or no ECT to CIP]]</p> 
+			<p>You'll need to follow the steps to choose your training materials and add your ECTs and mentors.</p>
+
+			<p>[[If changing from DIY to no ECTs]]</p> 
+			<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year. 
+
+			<p>If any ECTs do join your school this year, you need to use this service to let us know.</p>
+
+			<p>[[If changing from no ECTs to DIY]]</p>
+			<p class="govuk-body">You'll need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
+				<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
+
+			<p>[[If changing from FIP or CIP to no ECTs]] - content tbc</p>	
+
+			<p>[[If changing from FIP or CIP to DIY]] - content tbc</p>
+
+			<p>[[If changing from FIP to CIP]] - content tbc</p>
+
+			<p>[[If changing from CIP to FIP]] - content tbc</p>
+
 
 			{% else %}
 
-			<p class="govuk-body">You have chosen to
+			<p class="govuk-body">You've chosen to
 			
 				{% if (data['induction-programme'] === "FIP") %}
-					use a training provider, funded by the DfE (full induction programme).
+					use a training provider, funded by the DfE.
 				{% elseif (data['induction-programme'] === "CIP") %}
-					deliver your own programme using DfE accredited materials (core induction programme).
+					deliver your own programme using DfE accredited materials.
 				{% elseif (data['induction-programme'] === "DYO") %}
 					design and deliver your own programme based on the Early Career Framework (ECF).
 				{% elseif (data['induction-programme'] === "noECT") %}
-					opt out of notifications because you don’t expect to have any early career teachers starting in 2021.
+					opt out of notifications, because you do not expect any early career teachers to join this academic year.
 				{% elseif (data['induction-programme'] === "temphold") %}
 					use a training provider funded by your school.
 				{% endif %}

--- a/app/views/sprint-20/schools/confirm-induction-programme.html
+++ b/app/views/sprint-20/schools/confirm-induction-programme.html
@@ -81,7 +81,7 @@
 
 				{% if data['change-programme'] == "Yes" %}
 				<!-- This removes the change-programme value so we are out of that loop -->
-				<input type="hidden" name="change-programme" id="change-programme" value="" />
+				<!-- <input type="hidden" name="change-programme" id="change-programme" value="" /> -->
 				{% endif %}
 								
 				{{ govukButton({

--- a/app/views/sprint-20/schools/confirm-induction-programme.html
+++ b/app/views/sprint-20/schools/confirm-induction-programme.html
@@ -2,7 +2,7 @@
 {% set schoolSignedIn = true %}
 
 {% if data['change-programme'] == "Yes" %}
-	{% set pageHeading = "Are you sure you want to change how you'll run your training?" %}
+	{% set pageHeading = "Are you sure you want to change how you’ll run your training?" %}
 {% else %}
 	{% set pageHeading = "Confirm your training programme" %}
 {% endif %}
@@ -16,34 +16,35 @@
 
       		{{ macroPageHeader.pageHeader(pageHeading,pageSection) }}
 
+			<!-- if changing programme -->
+			{% if data['change-programme'] == "Yes" %}				
 
-			{% if data['change-programme'] == "Yes" %}
+				{% if (data['induction-programme'] === "FIP") %}
 
-			<p>**Brian - I think we need to make variable content for each of the combinations below**</p>
+					<p>You’ll need to follow the steps to choose a training provider and add your ECTs and mentors.</p>
 
-			<p>[[If changing from DIY or no ECT to FIP]]</p> 
-			<p>You'll need to follow the steps to choose a training provider and add your ECTs and mentors.</p>
+				{% elseif (data['induction-programme'] === "CIP") %}
 
-			<p>[[If changing from DIY or no ECT to CIP]]</p> 
-			<p>You'll need to follow the steps to choose your training materials and add your ECTs and mentors.</p>
+					<p>You’ll need to follow the steps to choose your training materials and add your ECTs and mentors.</p>
+				
+				{% elseif (data['induction-programme'] === "DYO") %}
 
-			<p>[[If changing from DIY to no ECTs]]</p> 
-			<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year. 
+					<!-- noECT to DIY  -->
+					<p class="govuk-body">You’ll need to design a 2-year programme of support and training that covers every ’learn that’ and ’learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
+					<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
+				
+				{% elseif (data['induction-programme'] === "noECT") %}
+					
+					<!-- DIY to noECT -->
+					<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
+					<p>If any ECTs do join your school this year, you need to use this service to let us know.</p>				
+			
+				{% endif %}			
 
-			<p>If any ECTs do join your school this year, you need to use this service to let us know.</p>
-
-			<p>[[If changing from no ECTs to DIY]]</p>
-			<p class="govuk-body">You'll need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
-				<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
-
-			<p>[[If changing from FIP or CIP to no ECTs]] - content tbc</p>	
-
-			<p>[[If changing from FIP or CIP to DIY]] - content tbc</p>
-
-			<p>[[If changing from FIP to CIP]] - content tbc</p>
-
-			<p>[[If changing from CIP to FIP]] - content tbc</p>
-
+				<!-- <p>[[If changing from FIP or CIP to no ECTs]] - content tbc</p>	
+				<p>[[If changing from FIP or CIP to DIY]] - content tbc</p>
+				<p>[[If changing from FIP to CIP]] - content tbc</p>
+				<p>[[If changing from CIP to FIP]] - content tbc</p> -->
 
 			{% else %}
 
@@ -65,14 +66,16 @@
 			{% endif %}
       		
 			<form method="post" action="provision-confirmed" >
+
 				{% if data['change-programme'] == "Yes" %}
+				<!-- This removes the change-programme value so we are out of that loop -->
 				<input type="hidden" name="change-programme" id="change-programme" value="" />
-				{% endif %}			
+				{% endif %}
 								
 				{{ govukButton({
 					text: "Confirm"
 		  		}) }}
-				  
+
 			</form>	
 			
     </div>

--- a/app/views/sprint-20/schools/manage-your-training.html
+++ b/app/views/sprint-20/schools/manage-your-training.html
@@ -76,7 +76,7 @@
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Programme</dt>					
 						<dd class="govuk-summary-list__value">DfE accredited materials</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Materials</dt>
@@ -103,7 +103,7 @@
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Programme</dt>					
 						<dd class="govuk-summary-list__value">Training provider, funded by the DfE</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Training provider</dt>
@@ -150,7 +150,7 @@
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">Programme</dt>					
 							<dd class="govuk-summary-list__value">Expecting no early career teachers</dd>
-							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-signed-in/dyo/dyo-cohort-nextsteps-noect">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
+							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="../school-signed-in/dyo/dyo-cohort-nextsteps-noect">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
 						</div>					
 				
 				{% elif (data['induction-programme'] === "temphold") %}

--- a/app/views/sprint-20/schools/programme-choice.html
+++ b/app/views/sprint-20/schools/programme-choice.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% set schoolSignedIn = true %}
 
-{% set pageHeading = "View details about your induction programme" %}
+{% set pageHeading = "About your training programme" %}
 {% set pageSection = "Acme Primary School" %}
 {% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
 
@@ -87,8 +87,8 @@
 					]
 				}) }} -->
 			
-				<h2 class="govuk-heading-m">Programme</h2>		
-				<p>Design and deliver your own programe based on the Early Career Framework (ECF)</p>
+				<h2 class="govuk-heading-m">Programme choice</h2>		
+				<p>Your school has chosen to design and deliver your own programe based on the Early Career Framework (ECF).</p>
 				
 				<h2 class="govuk-heading-m">How to run this programme</h2>		
 				<p class="govuk-body">You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
@@ -106,6 +106,16 @@
        			
       			<h2 class="govuk-heading-m">Change how you run your programme</h2>
       			<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>
+
+      	{% elif data['induction-programme'] == "noECT" %}	
+
+
+      			<h2 class="govuk-heading-m">Programme choice</h2>	
+      			<p>Your school has told us you do not expect any early career teachers (ECTs) to join you in the 2021 to 2022 academic year.</p>
+			
+       			
+      			<h2 class="govuk-heading-m">Tell us if you do expect ECTs to join you in this academic year</h2>
+      			<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Update your information</a> and follow the steps to set up your training programme.</p>
 
 			{% endif %}
 

--- a/app/views/sprint-20/schools/provision-confirmed.html
+++ b/app/views/sprint-20/schools/provision-confirmed.html
@@ -2,7 +2,7 @@
 {% set showBackLink = false %}
 {% set schoolSignedIn = true %}
 
-{% set pageHeading = "Induction programme confirmed" %}
+{% set pageHeading = "Training programme confirmed" %}
 {% set pageSection = "" %}
 {% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
 
@@ -18,35 +18,28 @@
 
       		{% if (data['induction-programme'] === "DYO") %}
       			
-				<h3 class="govuk-heading-m">What happens next</h3>
-      			<ul class="govuk-list govuk-list--bullet">
-        			<li>we will send you any relevant updates</li>
-					<li>you do not need to sign in to the service to set up your programme</li>
-					<li>if you change your mind about how you want to run your induction, contact: <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
-      			</ul>
+				<h2 class="govuk-heading-m">What happens next</h2>     
+        <p class="govuk-body">You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
+        <p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
 
-      			<h3 class="govuk-heading-m">What you can do now</h3>
-      			<p>The <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a> covers 8 standards. For every standard there are statements for early career teachers to “learn that” and “learn how to”.</p>
-      			<p class="govuk-body">You need to design training that covers all of these statements.</p>
-      			<p class="govuk-body">You must also ask your appropriate body what evidence you need to demonstrate that your programme is:</p>
-      			<ul class="govuk-list govuk-list--bullet">
-        			<li>based on the ECF</li>
-        			<li>meets the statutory requirements</li>
-      			</ul>
+          <h2 class="govuk-heading-m">Your ECTs and mentors</h2>  
+            <p class="govuk-body">You do not need to add information about your ECTs and mentors to this service.</p>  
 
-      			<h3 class="govuk-heading-m">What you need to do before your induction starts</h3>
-      			<ul class="govuk-list govuk-list--bullet">
-        			<li>make sure your early career teacher has enough time off in their timetable to complete training</li>
-        			<li>make sure that your induction tutor and mentor have the time to carry out their roles</li>
-      			</ul>
-
-      			<p><a class="govuk-link" href="https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"> See our statutory guidance</a> for details on time off, roles and responsibilities.</p>      			
+        <h2 class="govuk-heading-m">Your appropriate body</h2>  
+            <p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your programme:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>is based on the ECF</li>
+              <li>meets the statutory requirements</li>
+            </ul>
+            
+            <h2 class="govuk-heading-m">Change how you run your programme</h2>
+            <p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>    			
 
       		{% elif (data['induction-programme'] === "noECT") %}
 
 				<h3 class="govuk-heading-m">What happens next</h3>
-      			<p>We will contact [school name] in the next academic year.</p>
-      			<p>If you do employ early career teachers later this year, you can <a class="govuk-link" href="../nominations/resend-email">nominate someone to set up your programme.</a></p>      			
+      			<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
+      			<p>If any ECTs do join your school this year, you need to use this service to let us know.</a></p>      			
 
       		{% elif ((data['induction-programme'] == "FIP") or (data['induction-programme'] == "CIP")) %}
 
@@ -59,7 +52,6 @@
 			  <li>if you change your mind about how you want to run your training, contact: <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
 			</ul>
 
-			
 
 			{% endif %}
 			

--- a/app/views/sprint-20/schools/provision-confirmed.html
+++ b/app/views/sprint-20/schools/provision-confirmed.html
@@ -14,56 +14,57 @@
       		{{ govukPanel({
         		titleText: pageHeading        		
       		}) }}
-      
+			  
 
-      		{% if (data['induction-programme'] === "DYO") %}
+				{% if ((data['induction-programme'] == "FIP") or (data['induction-programme'] == "CIP")) %}
+
       			
-				<h2 class="govuk-heading-m">What happens next</h2>     
-        <p class="govuk-body">You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
-        <p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
+			  	{% elif (data['induction-programme'] === "DYO") %}
+      			
+					<h2 class="govuk-heading-m">What happens next</h2>     
+					<p class="govuk-body">You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
+					<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
 
-          <h2 class="govuk-heading-m">Your ECTs and mentors</h2>  
-            <p class="govuk-body">You do not need to add information about your ECTs and mentors to this service.</p>  
+					<h2 class="govuk-heading-m">Your ECTs and mentors</h2>  
+					<p class="govuk-body">You do not need to add information about your ECTs and mentors to this service.</p>  
 
-        <h2 class="govuk-heading-m">Your appropriate body</h2>  
-            <p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your programme:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>is based on the ECF</li>
-              <li>meets the statutory requirements</li>
-            </ul>
-            
-            <h2 class="govuk-heading-m">Change how you run your programme</h2>
-            <p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>    			
+					<h2 class="govuk-heading-m">Your appropriate body</h2>  
+					<p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your programme:</p>
+					<ul class="govuk-list govuk-list--bullet">
+						<li>is based on the ECF</li>
+						<li>meets the statutory requirements</li>
+					</ul>
+				
+					<h2 class="govuk-heading-m">Change how you run your programme</h2>
+					<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>    			
 
-      		{% elif (data['induction-programme'] === "noECT") %}
+      			{% elif (data['induction-programme'] === "noECT") %}
 
-				<h3 class="govuk-heading-m">What happens next</h3>
-      			<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
-      			<p>If any ECTs do join your school this year, you need to use this service to let us know.</a></p>      			
-
-      		{% elif ((data['induction-programme'] == "FIP") or (data['induction-programme'] == "CIP")) %}
-
-      			<!-- <p>You can now view the next steps for your programme.</p>      			      			 -->
-			{% elif (data['induction-programme'] === "temphold") %}
-			<h3 class="govuk-heading-m">What happens next</h3>
-			<ul class="govuk-list govuk-list--bullet">
-			  <li>you do not need to use this service to set up your training programme</li>
-			  <li>you will need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">training provider</a>, approved by the DfE</li>
-			  <li>if you change your mind about how you want to run your training, contact: <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
-			</ul>
-
-
-			{% endif %}
+					<h3 class="govuk-heading-m">What happens next</h3>
+      				<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
+      				<p>If any ECTs do join your school this year, you need to use this service to let us know.</a></p>      			
 			
-			{% if (data['induction-programme'] != "noECT") %}
-			<form class="form" action="manage-your-training" method="post" class="govuk-!-margin-bottom-8">
-        		
-				{{ govukButton({
-					  text: "Continue"
-				}) }}
+				{% elif (data['induction-programme'] === "temphold") %}
+				
+					<h3 class="govuk-heading-m">What happens next</h3>
+					<ul class="govuk-list govuk-list--bullet">
+			  			<li>you do not need to use this service to set up your training programme</li>
+			  			<li>you will need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">training provider</a>, approved by the DfE</li>
+			  			<li>if you change your mind about how you want to run your training, contact: <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
+					</ul>
 
-			</form>
-			{% endif %}
+				{% endif %}
+			
+				{% if (data['induction-programme'] != "noECT") %}
+				
+					<form class="form" action="manage-your-training" method="post" class="govuk-!-margin-bottom-8">
+        		
+					{{ govukButton({
+						text: "Continue"
+					}) }}
+					</form>
+				
+				{% endif %}
 
     	</div>
   	</div>


### PR DESCRIPTION
This PR covers:

- removing 'internal' names from the choose training programme screen, and simplifying the links to guidance
- updating the status message for SITs who have not chosen a programme
- adding variable content for the 'Are you sure you want to change how you'll run your training?' screen
- adding content to the 'provision confirmed' screen for no ECTs and DIY (FIP and CIP are covered by a separate ticket)
- changing 'change' to 'view details' on the 'Manage your training' screen
- small updates to the 'About your training programme' page (formerly 'View details about your induction programme')