### PR TITLE
Moves content from View details to change confirmation screen

### DIFF
--- a/app/views/sprint-21/schools/confirm-induction-programme.html
+++ b/app/views/sprint-21/schools/confirm-induction-programme.html
@@ -21,17 +21,17 @@
 
 				{% if (data['induction-programme'] === "FIP") %}
 
-					<p>You have chosen to use a training provider, funded by the DfE.</p>
-					<p>You’ll need to follow the steps to:
+					<p>You've chosen to use a training provider, funded by the DfE.</p>
+					<p>You’ll need to:
 						<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
 							<li>choose a training provider </li>
-							<li>add your ECTs and mentors.</li>
+							<li>add your ECTs and mentors</li>
 						</ul>
 
 				{% elseif (data['induction-programme'] === "CIP") %}
 					
-					<p>You have chosen to deliver your own programme using DfE accredited materials.</p>
-					<p>You’ll need to follow the steps to:
+					<p>You've chosen to deliver your own programme using DfE accredited materials.</p>
+					<p>You’ll need to:
 					<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
 						<li>choose your training materials</li>
 						<li>add your ECTs and mentors</li>
@@ -40,15 +40,15 @@
 				{% elseif (data['induction-programme'] === "DYO") %}
 
 					<!-- noECT to DIY  -->
-					<p>You are choosing to design and deliver your own programme based on the Early Career Framework (ECF).</p>
+					<p>You're choosing to design and deliver your own programme based on the Early Career Framework (ECF).</p>
 					<p class="govuk-body">You’ll need to design a 2-year programme of support and training that covers every ’learn that’ and ’learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
 					<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
 				
 				{% elseif (data['induction-programme'] === "noECT") %}
 					
 					<!-- DIY to noECT -->
-					<p>You are not expecting any early career teachers to join.</p>
-					<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
+					<p>You've told us that you're not expecting any early career teachers (ECTs) to join this year.</p>
+					<p>Your school will not receive any more messages about statutory inductions for ECTs until the next academic year.</p>
 					<p>If any ECTs do join your school this year, you need to use this service to let us know.</p>				
 			
 				{% endif %}			

--- a/app/views/sprint-21/schools/manage-your-training.html
+++ b/app/views/sprint-21/schools/manage-your-training.html
@@ -73,7 +73,7 @@
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Programme</dt>					
 						<dd class="govuk-summary-list__value">DfE accredited materials</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Materials</dt>
@@ -100,7 +100,7 @@
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Programme</dt>					
 						<dd class="govuk-summary-list__value">Training provider, funded by the DfE</dd>
-						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
+						<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">Training provider</dt>
@@ -139,7 +139,7 @@
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">Programme</dt>					
 							<dd class="govuk-summary-list__value">Design and deliver your own programme based on the Early Career Framework (ECF)</dd>
-							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
+							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
 						</div>					
 				
 				{% elif data['induction-programme'] == "noECT" %}
@@ -147,7 +147,7 @@
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">Programme</dt>					
 							<dd class="govuk-summary-list__value">Expecting no early career teachers</dd>
-							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">View details<span class="govuk-visually-hidden"> programme</span></a></dd>
+							<dd class="govuk-summary-list__actions"><a class="govuk-link" href="programme-choice">Change<span class="govuk-visually-hidden"> programme</span></a></dd>
 						</div>					
 				
 				{% elif (data['induction-programme'] === "temphold") %}
@@ -177,7 +177,7 @@
 
 
 			{% if ((data['induction-programme'] == "FIP") and (data['InPartnership'] == "Yes")) %}								
-			<p class="govuk-body">If this doesn’t look right, <a href="report-incorrect-signup">report that your school has been confirmed incorrectly</a>.</p>
+			<p class="govuk-body">If this does not look right, <a href="report-incorrect-signup">report that your school has been confirmed incorrectly</a>.</p>
 			<p>This link will expire on {{ defaults.linkExpire() }}.</p>
 			{% endif %}
 

--- a/app/views/sprint-21/schools/programme-choice.html
+++ b/app/views/sprint-21/schools/programme-choice.html
@@ -3,7 +3,7 @@
 
 
 {% if((data['induction-programme'] == "DYO") or ( data['induction-programme'] == "noECT" )) %}
-{% set pageHeading = "About your training programme" %}
+{% set pageHeading = "Change how you run your programme" %}
 {% else %}
 {% set pageHeading = "Choose an induction programme" %}
 {% endif %}
@@ -31,7 +31,6 @@
 						]
 					}) }} -->
 			
-				<h2 class="govuk-heading-m">Changing your programme</h2>
 				<p class="govuk-body">If your school wants to use a training provider, funded by the DfE, you should:</p>
 				<ul class="govuk-list govuk-list--bullet">
 					<li>contact your local Teaching School Hub</li>
@@ -63,7 +62,6 @@
 					]
 				}) }} -->
 				
-				<h2 class="govuk-heading-m">Changing your programme</h2>
 				<p class="govuk-body">If your school has decided to:</p>
 				<ul class="govuk-list govuk-list--bullet">
 				  <li>deliver your own programme using the DfE accredited materials</li>
@@ -75,41 +73,22 @@
 		
 				<p class="govuk-body">You need to:</p>		  
 				<ol class="govuk-list govuk-list--number">
-				  <li>Speak to your training provider (if you have signed up with one).</li>
+				  <li>Speak to your training provider, if you've signed up with one.</li>
 				  <li>Contact: <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
 				</ol>
 
 
 
-			{% elif data['induction-programme'] == "DYO" %}						
-			
-				<h2 class="govuk-heading-m">Programme choice</h2>		
+			{% elif data['induction-programme'] == "DYO" %}							
 				<p>Your school has chosen to design and deliver your own programme based on the Early Career Framework (ECF).</p>
 				
-				<h2 class="govuk-heading-m">How to run this programme</h2>		
-				<p class="govuk-body">You need to design a 2-year programme of support and training that covers every ‘learn that’ and ‘learn how to’ statement in the <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework">Early Career Framework (ECF)</a>.</p>
-				<p><a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction"> See our statutory guidance</a> for information about funding, time off, and roles.</p> 
-
-			  	<h2 class="govuk-heading-m">Your ECTs and mentors</h2>	
-      			<p class="govuk-body">You do not need to add information about your ECTs and mentors to this service.</p>	 
-
-				<h2 class="govuk-heading-m">Your appropriate body</h2>	
-      			<p class="govuk-body">Contact your appropriate body to find out what evidence is needed to demonstrate that your programme:</p>
-      			<ul class="govuk-list govuk-list--bullet">
-        			<li>is based on the ECF</li>
-        			<li>meets the statutory requirements</li>
-      			</ul>
-       			
-      			<h2 class="govuk-heading-m">Change how you run your programme</h2>
-      			<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>
+      			<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the other options available</a> for your school.</p>
 
       		{% elif data['induction-programme'] == "noECT" %}	
-
-      			<h2 class="govuk-heading-m">Programme choice</h2>	
+	
       			<p>Your school has told us you do not expect any early career teachers (ECTs) to join you in the 2021 to 2022 academic year.</p>
 			
-				<h2 class="govuk-heading-m">Change how you run your programme</h2>
-				<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school.</p>
+				<p class="govuk-body"><a class="govuk-link" href="choose-induction-programme?change-programme=Yes">Check the options available</a> for your school if this changes.</p>
       		
 			{% endif %}
 

--- a/app/views/sprint-21/schools/provision-confirmed.html
+++ b/app/views/sprint-21/schools/provision-confirmed.html
@@ -17,9 +17,49 @@
       		}) }}
 			  
 
-				{% if ((data['induction-programme'] == "FIP") or (data['induction-programme'] == "CIP")) %}
 
-			  		<p><a href="manage-your-training">Complete the steps to set up your training programme</a></p>					
+			  	{% if (data['induction-programme'] === "FIP") %}
+
+			  		<h2 class="govuk-heading-m">What happens next</h2>
+
+			  		<p class="govuk-body">1. You need to <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">choose one of the 6 DfE-funded training providers (opens in a new tab)</a> as soon as possible.</p> 
+
+			  		<p class="govuk-body">2. <a class="govuk-link" href="https://www.gov.uk/guidance/teaching-school-hubs">Contact your local teaching school hub (opens in a new tab)</a> to ask for guidance, and confirm your choice of provider.</p>
+
+			  		<p class="govuk-body">You do not need to let the DfE know which provider you choose. Your training provider will contact us to arrange funding.</p>
+
+			  		<h2 class="govuk-heading-m">Your ECTs and mentors</h2>
+
+					<p class="govuk-body">You need to tell us each ECT and mentor’s name and email address as soon as possible.</p>
+
+					<p class="govuk-body">We’ll then contact them to ask for more information. We’ll use this to check they’re eligible for this funded training and support.</p>
+
+					<p class="govuk-body"><a class="govuk-link" href="/participants">Add your ECTs and mentors</a>
+
+					<h2 class="govuk-heading-m">Your appropriate body</h2>  
+					<p class="govuk-body">Your school needs to <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body">have an appropriate body in place.</a></p>
+
+
+					{% elif (data['induction-programme'] === "CIP") %}
+
+			  		<h2 class="govuk-heading-m">What happens next</h2>
+
+			  		<p class="govuk-body">1. You need to <a class="govuk-link" href="https://www.early-career-framework.education.gov.uk/"> compare and choose which DfE-accredited materials you want to use (opens in a new tab)</a> as soon as possible.</p> 
+
+			  		<p class="govuk-body">2. Use this service to <a class="govuk-link" href="/manage-your-training?induction-programme=CIP">tell us which materials you want to use</a>.</p>
+
+			  		<h2 class="govuk-heading-m">Your ECTs and mentors</h2>
+
+					<p class="govuk-body">You need to tell us each ECT and mentor’s name and email address as soon as possible.</p>
+
+					<p class="govuk-body">We’ll then contact them to ask for more information. We’ll use this to check they’re eligible for this funded training and support.</p>
+
+					<p class="govuk-body">Eligible ECTs and mentors will be emailed a link to your chosen materials once these checks are completed.</p>
+
+					<p class="govuk-body"><a class="govuk-link" href="/participants">Add your ECTs and mentors</a>
+
+					<h2 class="govuk-heading-m">Your appropriate body</h2>  
+					<p class="govuk-body">Your school needs to <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body">have an appropriate body in place.</a></p>
       			
 			  	{% elif (data['induction-programme'] === "DYO") %}
       			
@@ -41,7 +81,7 @@
       			{% elif (data['induction-programme'] === "noECT") %}
 
 					<h3 class="govuk-heading-m">What happens next</h3>
-      				<p>Your school will not receive any more messages about statutory inductions for early career teachers (ECTs) until the next academic year.</p>
+      				<p>Your school will not receive any more messages about statutory inductions for ECTs until the next academic year.</p>
       				<p>If any ECTs do join your school this year, you need to use this service to let us know.</a></p>      			
 			
 				{% elif (data['induction-programme'] === "temphold") %}
@@ -49,7 +89,7 @@
 					<h3 class="govuk-heading-m">What happens next</h3>
 					<ul class="govuk-list govuk-list--bullet">
 			  			<li>you do not need to use this service to set up your training programme</li>
-			  			<li>you will need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">training provider</a>, approved by the DfE</li>
+			  			<li>you'll need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">training provider</a>, approved by the DfE</li>
 			  			<li>if you change your mind about how you want to run your training, contact: <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a></li>
 					</ul>
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDRP-906?atlOrigin=eyJpIjoiYjNjMjVjYTJkNmYxNGE1ZmE2YThlODkxMmE2OGQ4NTIiLCJwIjoiaiJ9

- 'View details' has become 'Change'
- 'About your training programme' has become 'Change how you run your programme'
- Content has moved to the new confirmation screens