### PR TITLE
822 content update

### DIFF
--- a/app/views/latest/schools/sign-up-to-training-provider.html
+++ b/app/views/latest/schools/sign-up-to-training-provider.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% set schoolSignedIn = true %}
 
-{% set pageHeading = "Signing up with a training provider" %}
+{% set pageHeading = "Sign up with a training provider" %}
 {% set pageSection = "2021 cohort" %}
 {% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
 
@@ -15,23 +15,14 @@
 
       		
 
-				<p class="govuk-body">You sign up with a training provider directly.</p>
-				<p class="govuk-body">They will confirm this with the DfE and you will be notified. (You do not need to confirm this here.)</p>
+				<p class="govuk-body">You need to <a class="govuk-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">choose one of the 6 DfE-funded training providers (opens in a new tab)</a>.</p>
 
-				<h2 class="govuk-heading-m">How you can sign up with a training provider</h2>
-				<p class="govuk-body">There are a few ways you can sign up with a training provider:</p>
-				<p class="govuk-body">The easiest way to sign up with a training provider is to contact your local <a href="https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub">Teaching School Hub (TSH)</a>. They can talk you through how to access this support for your early career teachers and mentors.</p>
+				<h2 class="govuk-heading-m">How to make your choice</h2> 
 
-				<p class="govuk-body">You can also explore what our 6 providers have to offer and contact them directly:</p>
-      			<ul class="govuk-list govuk-list--bullet">
-        			<li><a class="govuk-link" href="https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6">Ambition Institute</a></li>
-					<li><a class="govuk-link" href="https://bestpracticenet.co.uk/early-career-framework">Best Practice Network (home of Outstanding Leaders Partnership)</a></li>
-					<li><a class="govuk-link" href="https://www.capita.com/expertise/supporting-teachers-in-early-career">Capita with lead academic partner the University of Birmingham</a></li>
-					<li><a class="govuk-link" href="https://www.educationdevelopmenttrust.com/ecf">Education Development Trust</a></li>
-					<li><a class="govuk-link" href="https://www.teachfirst.org.uk/early-career-framework">Teach First</a></li>
-					<li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe-early-career-framework">UCL Institute of Education</a></li>
-      			</ul>
-      			<p class="govuk-body">These training providers and their local partners will also be recruiting schools in the next few months, so you may hear from them.</p>
+			  		<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/guidance/teaching-school-hubs">Contact your local teaching school hub (opens in a new tab)</a> to ask for guidance, and confirm your choice of provider.</p>
+
+			  		<p class="govuk-body">You do not need to let the DfE know which provider you choose. Your training provider will contact us to arrange funding.</p>
+
 				
 
 				<p class="govuk-body-s govuk-!-margin-top-9"><a href="manage-your-training?InPartnership=Yes">Partnership created</a></p>


### PR DESCRIPTION
PR updates include:

- Updating the H1 (active)
- Removing individual links to providers, but linking to the statutory guidance for these instead
- Adding a sub header to emphasise that schools should contact their teaching hub for advice and to confirm their choice

https://dfedigital.atlassian.net/browse/CPDRP-822?atlOrigin=eyJpIjoiZTQ5ZGU4M2MxN2RjNGU2Nzg2MzRmNjBjZjhiMTIyNWUiLCJwIjoiaiJ9