### PR TITLE
renamed logic for induction-programme to training-programme

### DIFF
--- a/app/views/admin/listings.html
+++ b/app/views/admin/listings.html
@@ -107,15 +107,15 @@
             <h3 class="govuk-heading-m">Core induction programme (CIP)</h3>
             <p>When a school is delivering their own using DfE accredited materials. <span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355308879313&cot=14">User journey on Miro</a></span></p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?induction-programme=CIP" >Manage your training</a></li>
+                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?training-programme=CIP" >Manage your training</a></li>
                 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/?induction-programme=CIP" >Do you know which accredited materials you want to use?</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/which?induction-programme=CIP" >Which training materials do you want this cohort to use?</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/confirmation?induction-programme=CIP" >Training materials confirmed</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/your-accredited-materials?induction-programme=CIP" >Your accredited materials</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/?training-programme=CIP" >Do you know which accredited materials you want to use?</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/which?training-programme=CIP" >Which training materials do you want this cohort to use?</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/confirmation?training-programme=CIP" >Training materials confirmed</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/materials/your-accredited-materials?training-programme=CIP" >Your accredited materials</a></li>
                 </ul>
                 <ul class="govuk-list govuk-list--bullet">
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?induction-programme=CIP" >Choose your induction programme</a></li>                    
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?training-programme=CIP" >Choose your induction programme</a></li>                    
                 </ul>                
                 <!-- No longer needed -->            
                 <!-- <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/school-signed-in/cip/cip-cohort-detail" >2021/22 cohort: use DfE accredited materials</a></li> -->
@@ -127,24 +127,24 @@
             <h3 class="govuk-heading-m">Full induction programme (FIP)</h3>
             <p>When a school is using a training provider funded by DfE. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355306758748&cot=14">User journey on Miro</a></span></p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?induction-programme=FIP" >Manage your training</a></li>                                
+                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?training-programme=FIP" >Manage your training</a></li>                                
                 <ul class="govuk-list govuk-list--bullet">
                     <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/sign-up-to-training-provider" >Signing up with a training provider</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?induction-programme=FIP" >Choose your induction programme</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/report/incorrect-signup?induction-programme=FIP" >Report that your school has been signed up incorrectly</a></li>
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/report/submitted?induction-programme=FIP" >Your report has been submitted</a></li>                
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?training-programme=FIP" >Choose your induction programme</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/report/incorrect-signup?training-programme=FIP" >Report that your school has been signed up incorrectly</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/report/submitted?training-programme=FIP" >Your report has been submitted</a></li>                
                 </ul>                
                 <p>Notified via email of a new partnership. <span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457354439630103&cot=14">User journey on Miro</a></span></p>                
-                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/emails/provider-confirmed?induction-programme=FIP" >Provider confirmed (email)</a></li>
+                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/emails/provider-confirmed?training-programme=FIP" >Provider confirmed (email)</a></li>
                 
             </ul>
 
             <h3 class="govuk-heading-m">Deliver your own (DYO)</h3>
             <p>When a school designs and deliver their own programme based on the Early Career Framework (ECF).</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
-                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?induction-programme=DYO" >Manage your training</a></li>                
+                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?training-programme=DYO" >Manage your training</a></li>                
                 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
-                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?induction-programme=DYO" >Choose your induction programme</a></li>
+                    <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/programme-choice?training-programme=DYO" >Choose your induction programme</a></li>
                 </ul>                
             </ul>
 
@@ -152,7 +152,7 @@
             <h3 class="govuk-heading-m">Not expecting any ECT (noECT)</h3>
             <p>When a school is not expecting to have any ECTs but has an induction tutor.</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
-                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?induction-programme=noECT" >Manage your training</a></li>                                
+                <li><a class="govuk-link" href="/{{ defaults.sprintNo() }}/schools/manage-your-training?training-programme=noECT" >Manage your training</a></li>                                
             </ul>
 
                         

--- a/app/views/sprint-21/listings-21.html
+++ b/app/views/sprint-21/listings-21.html
@@ -107,15 +107,15 @@
             <h3 class="govuk-heading-m">Core induction programme (CIP)</h3>
             <p>When a school is delivering their own using DfE accredited materials. <span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355308879313&cot=14">User journey on Miro</a></span></p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-                <li><a class="govuk-link" href="schools/manage-your-training?induction-programme=CIP" >Manage your training</a></li>
+                <li><a class="govuk-link" href="schools/manage-your-training?training-programme=CIP" >Manage your training</a></li>
                 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
-                    <li><a class="govuk-link" href="schools/materials/?induction-programme=CIP" >Do you know which accredited materials you want to use?</a></li>
-                    <li><a class="govuk-link" href="schools/materials/which?induction-programme=CIP" >Which training materials do you want this cohort to use?</a></li>
-                    <li><a class="govuk-link" href="schools/materials/confirmation?induction-programme=CIP" >Training materials confirmed</a></li>
-                    <li><a class="govuk-link" href="schools/materials/your-accredited-materials?induction-programme=CIP" >Your accredited materials</a></li>
+                    <li><a class="govuk-link" href="schools/materials/?training-programme=CIP" >Do you know which accredited materials you want to use?</a></li>
+                    <li><a class="govuk-link" href="schools/materials/which?training-programme=CIP" >Which training materials do you want this cohort to use?</a></li>
+                    <li><a class="govuk-link" href="schools/materials/confirmation?training-programme=CIP" >Training materials confirmed</a></li>
+                    <li><a class="govuk-link" href="schools/materials/your-accredited-materials?training-programme=CIP" >Your accredited materials</a></li>
                 </ul>
                 <ul class="govuk-list govuk-list--bullet">
-                    <li><a class="govuk-link" href="schools/programme-choice?induction-programme=CIP" >Choose your induction programme</a></li>                    
+                    <li><a class="govuk-link" href="schools/programme-choice?training-programme=CIP" >Choose your induction programme</a></li>                    
                 </ul>                
                 <!-- No longer needed -->            
                 <!-- <li><a class="govuk-link" href="school-signed-in/cip/cip-cohort-detail" >2021/22 cohort: use DfE accredited materials</a></li> -->
@@ -127,24 +127,24 @@
             <h3 class="govuk-heading-m">Full induction programme (FIP)</h3>
             <p>When a school is using a training provider funded by DfE. <br /><span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457355306758748&cot=14">User journey on Miro</a></span></p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-                <li><a class="govuk-link" href="schools/manage-your-training?induction-programme=FIP" >Manage your training</a></li>                                
+                <li><a class="govuk-link" href="schools/manage-your-training?training-programme=FIP" >Manage your training</a></li>                                
                 <ul class="govuk-list govuk-list--bullet">
                     <li><a class="govuk-link" href="schools/sign-up-to-training-provider" >Signing up with a training provider</a></li>
-                    <li><a class="govuk-link" href="schools/programme-choice?induction-programme=FIP" >Choose your induction programme</a></li>
-                    <li><a class="govuk-link" href="schools/report/incorrect-signup?induction-programme=FIP" >Report that your school has been signed up incorrectly</a></li>
-                    <li><a class="govuk-link" href="schools/report/submitted?induction-programme=FIP" >Your report has been submitted</a></li>                
+                    <li><a class="govuk-link" href="schools/programme-choice?training-programme=FIP" >Choose your induction programme</a></li>
+                    <li><a class="govuk-link" href="schools/report/incorrect-signup?training-programme=FIP" >Report that your school has been signed up incorrectly</a></li>
+                    <li><a class="govuk-link" href="schools/report/submitted?training-programme=FIP" >Your report has been submitted</a></li>                
                 </ul>                
                 <p>Notified via email of a new partnership. <span class="miro-link"><a href="https://miro.com/app/board/o9J_ldVNkCY=/?moveToWidget=3074457354439630103&cot=14">User journey on Miro</a></span></p>                
-                <li><a class="govuk-link" href="emails/provider-confirmed?induction-programme=FIP" >Provider confirmed (email)</a></li>
+                <li><a class="govuk-link" href="emails/provider-confirmed?training-programme=FIP" >Provider confirmed (email)</a></li>
                 
             </ul>
 
             <h3 class="govuk-heading-m">Deliver your own (DYO)</h3>
             <p>When a school designs and deliver their own programme based on the Early Career Framework (ECF).</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
-                <li><a class="govuk-link" href="schools/manage-your-training?induction-programme=DYO" >Manage your training</a></li>                
+                <li><a class="govuk-link" href="schools/manage-your-training?training-programme=DYO" >Manage your training</a></li>                
                 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-2">
-                    <li><a class="govuk-link" href="schools/programme-choice?induction-programme=DYO" >Choose your induction programme</a></li>
+                    <li><a class="govuk-link" href="schools/programme-choice?training-programme=DYO" >Choose your induction programme</a></li>
                 </ul>                
             </ul>
 
@@ -152,7 +152,7 @@
             <h3 class="govuk-heading-m">Not expecting any ECT (noECT)</h3>
             <p>When a school is not expecting to have any ECTs but has an induction tutor.</p>
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
-                <li><a class="govuk-link" href="schools/manage-your-training?induction-programme=noECT" >Manage your training</a></li>                                
+                <li><a class="govuk-link" href="schools/manage-your-training?training-programme=noECT" >Manage your training</a></li>                                
             </ul>
 
                         


### PR DESCRIPTION
Luke spotted an issue on the listings where it was using the old logic name for something we had changed. This should fix.