### PR TITLE
Add notes to participants in support

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -17,6 +17,14 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
+// TODO: Temporary fix
+// Remove when bug is resolved: https://github.com/alphagov/govuk-frontend/issues/2495
+.app-summary-list-fix {
+  .govuk-summary-list__value {
+    width: 50%;
+  }
+}
+
 .investigate {
   border-left-color: #d4351c;
 }

--- a/app/views/support/participant-add-notes.html
+++ b/app/views/support/participant-add-notes.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{% set showBackLink = true %}
+{% set pageHeading = "Edit notes" if data.support.notes else "Add notes" %}
+{% set pageSection = "Jane Doe" %}
+{% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form action="/support/participant" method="post">
+      {% set labelHtml %}
+        <span class="govuk-heading-xl govuk-!-margin-bottom-0">
+          <span class="govuk-caption-xl">{{ pageSection }}</span>
+          {{ pageHeading }}
+        </span>
+      {% endset %}
+
+      {{ govukTextarea({
+        label: {
+          html: labelHtml,
+          classes: "govuk-label--xl",
+          isPageHeading: true
+        },
+        rows: 15,
+        hint: {
+          text: "Give details about any decisions about, or changes made to this participant"
+        }
+      } | decorateFormAttributes(['support', 'notes']) ) }}
+
+      {{ govukButton({
+        text: 'Save'
+      }) }}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/support/participant-add-notes.html
+++ b/app/views/support/participant-add-notes.html
@@ -23,7 +23,7 @@
         },
         rows: 15,
         hint: {
-          text: "Give details about any decisions about, or changes made to this participant"
+          html: "Give details about any changes made to this participant.<br />Notes are for internal use only."
         }
       } | decorateFormAttributes(['support', 'notes']) ) }}
 

--- a/app/views/support/participant.html
+++ b/app/views/support/participant.html
@@ -1,0 +1,83 @@
+{% extends "layout.html" %}
+{% set showBackLink = true %}
+{% set name = 'Jane Doe' %}
+{% set pageHeading = name %}
+{% set pageSection = "" %}
+{% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
+
+{% block content %}
+  {{ macroPageHeader.pageHeader(pageHeading,pageSection) }}
+  {{ govukSummaryList({
+    classes: 'app-summary-list-fix',
+    rows: [
+      {
+        key: {
+          text: "Full name"
+        },
+        value: {
+          text: name
+        }
+      },
+      {
+        key: {
+          text: "Email address"
+        },
+        value: {
+          text: "email@example.com"
+        }
+      },
+      {
+        key: {
+          text: "Participant type"
+        },
+        value: {
+          text: "Early career teacher"
+        }
+      },
+      {
+        key: {
+          text: "Mentor"
+        },
+        value: {
+          text: "Joe Bloggs"
+        }
+      },
+      {
+        key: {
+          text: "School"
+        },
+        value: {
+          text: "Hayes College"
+        }
+      },
+      {
+        key: {
+          text: "Cohort"
+        },
+        value: {
+          text: "2021"
+        }
+      },
+      {
+        key: {
+          text: "Notes"
+        },
+        value: {
+          text: data.support.notes | nl2br | safe if data.support.notes else "No notes"
+        },
+        actions: {
+          items: [
+            {
+              href: "/support/participant-add-notes",
+              text: "Change notes" if data.support.notes else "Add notes"
+            }
+          ]
+        }
+      }
+    ]
+  }) }}
+
+  <p>
+    <a href="#">Delete participant</a>
+  </p>
+{% endblock %}


### PR DESCRIPTION
Reproduces the existing admin screen in the prototype:
https://teacher-cpd-design-history.herokuapp.com/support-for-cpd/service-november-2021/admin-view-participant.png

With the following design changes:

- adds a notes section
- shows "No notes" when there are none, with an "Add notes" action
- when there are notes the action says "Change notes"
- shows notes with formatted line breaks when given
- the title of the add notes page is either "Add notes" or "Edit notes" depending on whether the content is there or not

(The prototype does not currently include the top banner that support does - this should be added to the prototype rather than removed from the live service)

https://dfedigital.atlassian.net/browse/CST-244

![Screenshot 2022-01-12 at 17 09 38](https://user-images.githubusercontent.com/319055/149316590-7259ed20-8f2b-4d4a-bb38-705e28b3cd2b.png)

![Screenshot 2022-01-13 at 10 55 00](https://user-images.githubusercontent.com/319055/149317319-d17353c9-1039-44a5-bdd9-323c9b864464.png)

![Screenshot 2022-01-12 at 17 12 55](https://user-images.githubusercontent.com/319055/149316580-fc7fa1ad-fdd8-4138-b197-fc050841314d.png)