### PR TITLE
Check for redirects on nested form data

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -236,6 +236,13 @@ try {
 const checkRedirect = function (formdata) {
   if (Object.keys(formdata).length !== 0) {
     for (const key in formdata) {
+      if (typeof formdata[key] === 'object') {
+        const redirectPath = checkRedirect(formdata[key])
+        if (typeof redirectPath === 'string') {
+          return redirectPath
+        }
+      }
+
       if (typeof formdata[key] === 'string') {
         const match = formdata[key].match(/([^,]*).*redirect\(([^)]*)\)?/)
         if (match !== null) {


### PR DESCRIPTION
Previously the method was only checking the top level key values to see if there was a `redirect` in the value. Any nested values were being ignored.

Now we recurse through the formdata object, going deeper if we find an object.