### PR TITLE
[Multi cohort] - new ects 

### DIFF
--- a/app/views/includes/setup-training.html
+++ b/app/views/includes/setup-training.html
@@ -23,7 +23,7 @@ Not happy with including this. Some users may struggle and it's not best practic
 
 <div class="govuk-inset-text">
     <p>Do not include ECTs who started their training in the 2021 to 2022 academic year.</p>
-    <p>You can manage their training in the '2021 to 2022' tab.</p>
+    <p>You can manage their training in the ‘2021 to 2022’ tab.</p>
 </div>
 
 <form action="/nominations/next-academic-year" method="post" >

--- a/app/views/includes/setup-training.html
+++ b/app/views/includes/setup-training.html
@@ -1,16 +1,16 @@
-<h3 class="govuk-heading-m">How to set up training for ECTs starting in the 2022 to 2023 academic year</h3>
+<h3 class="govuk-heading-m">Tell us about any new ECTs starting training in the 2022 to 2023 academic year</h3>
 
 
 
 {% if data['inductionProgramme'] == "FIP" %}
-    <p>We need to know if:</p>
+    <p>We need to know:</p>
     <ul class="govuk-list govuk-list--bullet">
-        <li>your school expects any ECTs in the next academic year</li>
-        <li>you plan to change how you run training for any new ECTs</li>
+        <li>whether or not your school expects any new ECTs</li>
+        <li>if you plan to change how you run training for any new ECTs</li>
 {% else %}
     <p>We need to know:</p>
     <ul class="govuk-list govuk-list--bullet">
-        <li>if your school expects any ECTs in the next academic year</li>
+        <li>whether or not your school expects any new ECTs</li>
         <li>which training programme you want to use for any new ECTs</li>
 {% endif %}
 </ul>
@@ -18,10 +18,12 @@
 {# <p>It should only take a few minutes to get set up and you can change your answers later if you need to.</p> #}
 {# Old version of content can revert to if need be #}
 <p>You can change your answers later if you need to.</p>
-<p class="govuk-!-margin-bottom-5">It should only take a few minutes to get set up. </p>
+<!-- <p class="govuk-!-margin-bottom-5">It should only take a few minutes to get set up. </p>
+Not happy with including this. Some users may struggle and it's not best practice to suggest quick progress as standard. -->
 
 <div class="govuk-inset-text">
-    <p>You can do this later if you do not have the information you need yet.</p>
+    <p>Do not include ECTs who started their training in the 2021 to 2022 academic year.</p>
+    <p>You can manage their training in the '2021 to 2022' tab.</p>
 </div>
 
 <form action="/nominations/next-academic-year" method="post" >

--- a/app/views/nominations/next-academic-year.html
+++ b/app/views/nominations/next-academic-year.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% set schoolSignedIn = true %}
 
-{% set pageHeading = "Does your school expect any ECTs in the next academic year?" %}
+{% set pageHeading = "Does your school expect any new ECTs in the 2022 to 2023 academic year?" %}
 {% set pageSection = " " + data.schoolName + " " %}
 {% block pageTitle %}{{ macroPageTitle.pageTitle(pageHeading) }}{% endblock %}
 
@@ -13,7 +13,12 @@
         	{{ macroPageHeader.pageHeader(pageHeading,pageSection) }}
 
 			<p>ECTs are teachers who have finished their initial teacher training.</p>
-          	<p>It does not include teachers who started or completed their statutory induction before 1 September 2022.</p>
+          	<p>Do not include:
+            <ul  class="govuk-list govuk-list--bullet">
+            <li>ECTs who started training in the 2021 to 2022 academic year</li>
+            <li>any other teachers who started or completed their statutory induction before 1 September 2022</li>
+            </ul>
+            </p>
 
             {# If not already training using FIP then always look to see how they will run programme like new #}
             {% if (( data['inductionProgramme'] == "CIP") or ( data['inductionProgramme'] == "DYO" ) or ( data['inductionProgramme'] == "noECT" )) %}


### PR DESCRIPTION
Changes to the manage your training page from @JoDimbleby :

- Changed the sub-heading in the '2022 to 2023' tab to an instruction and aligned the content to the language from user feedback in UR
- Made it clearer in the first bullet that users are supposed to tell us "whether or not" they expect ECTs - I think some users will just skip this whole process if they're not expecting anyone for the upcoming academic year, but I think that's a sort of failsafe
- Removed the reference to the process taking a "few minutes". I remembered that this is an accessibility no-no. Can go into this further if necessary.
- Amended the inset text to warn users that this process is for starters in the 2022 to 2023 academic year only and directed their attention to the other tab.

In the 'Expect ECTs' question:

- rewrote the H1 to reflect user language and prominently include the word "NEW"
- added an extra bullet to re-emphasise not to add ECTs from the 2021 to 2022 academic year